### PR TITLE
type(x) changed to is_string(x), is_array(x) etc

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,11 +11,11 @@ class cgroups (
 
   validate_absolute_path($config_file_path)
 
-  if type($service_name) != 'string' {
+  if !is_string($service_name) {
     fail('cgroups::service_name must be a string.')
   }
 
-  if type($package_name) != 'string' and type($package_name) != 'array' {
+  if !is_string($package_name) and !is_array($package_name) {
     fail('cgroups::package_name must be a string or an array.')
   }
 


### PR DESCRIPTION
changed all type($x) functions to is_<datatype>($x) since type is used as language word and deprecated in stdlib.