### PR TITLE
Drop support for Puppet v4 without strict variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - PUPPET_GEM_VERSION="~> 4.1.0"
     - PUPPET_GEM_VERSION="~> 4.2.0"
     - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4"
     - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 sudo: false
@@ -50,8 +49,6 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.2.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Puppet module to manage cgroups.
 
 [![Build Status](https://travis-ci.org/Ericsson/puppet-module-cgroups.png?branch=master)](https://travis-ci.org/Ericsson/puppet-module-cgroups)
 
-# Compatability
+# Compatibility
 
 This module has been tested to work on the following systems with Puppet v3
-(with and without the future parser) and Puppet v4 with Ruby versions 1.8.7,
-1.9.3, 2.0.0 and 2.1.0.
+(with and without the future parser) and Puppet v4 (with strict variables)
+using Ruby versions 1.8.7 (Puppet v3 only), 1.9.3, 2.0.0 and 2.1.0.
 
   * EL 6
   * SLED 11 SP2


### PR DESCRIPTION
This will speed up the testing matrix and ensure a higher standard of
code by enforcing strict variables.