### PR TITLE
Refactor of module for proposed  2.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -42,18 +41,6 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.3.0"
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -12,15 +12,25 @@ This module has been tested to work on the following systems with Puppet v3
 1.9.3, 2.0.0 and 2.1.0.
 
   * EL 6
+  * EL 7
   * SLED 11 SP2
 
-# Parameters
+# cgroup class
+
+## Parameters
 
 config_file_path
 ----------------
 Path to cgroups config file.
 
 - *Default*: '/etc/cgconfig.conf'
+
+config_d_path
+-------------
+Path to the .d configuration directory
+
+- *Default*: '/etc/cgconfig.d'
+
 
 service_name
 ------------
@@ -35,16 +45,43 @@ name of package that enables cgroups.
 - *RedHat*: 'libcgroup'
 - *Suse*: 'libcgroup1'
 
-cgconfig_mount
---------------
-where cgroups is mounted
+groups
+------
+A hash containing group resources to be configured (see below for cgroups::group resources)
 
-- *RedHat*: '/cgroup'
-- *Suse*: '/sys/fs/cgroup'
+Eg:
+```yaml
+cgroups::groups:
+  "user/mgw-all":
+    permissions:
+      task:
+        uid: root
+        gid: mgw-all
+      admin:
+        uid: root
+        gid: mgw-all
+    controllers:
+      cpuset:
+        "cpuset.mems": "0"
+        "cpuset.cpus": "0,1"
+```
+
+mounts
+------
+A hash containing mounts to be configured in /etc/cgconfig.conf
+
+Eg:
+```yaml
+cgroups::mounts:
+  cpu: /cgroup
+```
+
+NOTE: As of RedHat 7 default resource controllers are the domain of systemd therefore this setting should probably not be used unless you are managing a controller not yet supported by systemd such as net_prio
+
 
 cgconfig_content
 ----------------
-The content of the cgroup file, this is a required option.
+Optional, specify arbitary content for the cgconfig.conf file
 
 - *Default*: undef
 
@@ -56,19 +93,93 @@ A path to set 0777 permissions on. This is a fix for Suse that have a bug in set
 
 # Heira example with Suse 11.2 bugfix
 
-<pre>
+```yaml
 cgroups::user_path_fix: '/sys/fs/cgroup/user/mgw-all'
-cgroups::cgconfig_content: |
-  group user/mgw-all {
-   perm {
-    task {
-      uid = root;
-      gid = mgw-all;
-    } admin {
-      uid = root;
-      gid = mgw-all;
-    }
-   } cpu {
-   }
+cgroups::groups:
+  "user/mgw-all":
+    permissions:
+      task:
+        uid: root
+        gid: mgw-all
+      admin:
+        uid: root
+        gid: mgw-all
+    controllers:
+      cpuset:
+        "cpuset.mems": "0"
+        "cpuset.cpus": "0,1"
+```
+
+# cgroups::group defined type
+
+## Description
+
+The `cgroups::group` definition is used to configure cgroup entries in /etc/cgconfig.d.  
+
+## Parameters
+
+permissions
+-----------
+
+An optional hash containing permissions for the group.
+
+Eg
+```puppet
+  permissions => {
+    'task' => {
+      'uid' => 'root',
+      'gid' => 'mgw-all',
+    },
+    'admin' => {
+      'uid' => 'root',
+      'gid' => 'mgw-all',
+    },
   }
-</pre>
+```
+
+controllers
+-----------
+
+A hash containing the controllers for the group
+
+Eg
+```puppet
+  controllers => {
+    'cpuset' => { 
+      'cpuset.mems' => '0',
+      'cpuset.cpus' => '0,1'
+    }
+  }
+```
+
+target
+------
+
+Optional parameter to define where the configuration should be put.  By default the module will use the /etc/cgconfig.d directory
+
+## Full example
+
+```puppet
+cggroups::group { 'mgw/user':
+  permissions => {
+    'task' => {
+      'uid' => 'root',
+      'gid' => 'mgw-all',
+    },
+    'admin' => {
+      'uid' => 'root',
+      'gid' => 'mgw-all',
+    },
+  },
+  controllers => {
+    'cpuset' => { 
+      'cpuset.mems' => '0',
+      'cpuset.cpus' => '0,1'
+    }
+  }
+}
+```
+
+You can also specify `cgroups::groups` from hiera as a hash of group resources and they will be created by the base class using create_resources
+
+

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -1,0 +1,27 @@
+define cgroups::group (
+  $permissions = {},
+  $controllers = {},
+  $target      = undef,
+) {
+
+
+
+  if (!defined(Class['cgroups'])) {
+    fail('Must include cgroups module before declaring cgroups::group resources')
+  }
+
+  
+  if $target {
+    $target_real = $target
+  } else {
+    $target_real = "${::cgroups::config_d_path}/${name}.conf"
+  }
+
+  file { $target_real:
+    ensure  => file,
+    content => template('cgroups/group.conf.erb'),
+    notify  => Service[$cgroups::service_name],
+  }
+
+}
+

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -6,6 +6,9 @@ define cgroups::group (
 
 
 
+  validate_hash($permissions)
+  validate_hash($controllers)
+
   include ::cgroups
   
   if $target {
@@ -13,6 +16,8 @@ define cgroups::group (
   } else {
     $target_real = "${::cgroups::config_d_path}/${name}.conf"
   }
+
+  validate_absolute_path($target_real)
 
   file { $target_real:
     ensure  => file,

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -6,6 +6,8 @@ define cgroups::group (
 
 
 
+  $fscompat_name = regsubst($name, '\/', '-')
+
   validate_hash($permissions)
   validate_hash($controllers)
 
@@ -14,7 +16,7 @@ define cgroups::group (
   if $target {
     $target_real = $target
   } else {
-    $target_real = "${::cgroups::config_d_path}/${name}.conf"
+    $target_real = "${::cgroups::config_d_path}/${fscompat_name}.conf"
   }
 
   validate_absolute_path($target_real)

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -6,10 +6,7 @@ define cgroups::group (
 
 
 
-  if (!defined(Class['cgroups'])) {
-    fail('Must include cgroups module before declaring cgroups::group resources')
-  }
-
+  include ::cgroups
   
   if $target {
     $target_real = $target

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,8 +27,15 @@ class cgroups (
 
   case $::osfamily {
     'RedHat': {
-      $default_package_name   = 'libcgroup'
-      $default_cgconfig_mount = '/cgroup'
+      case $::operatingsystemmajrelease {
+        '6','7': {
+          $default_package_name   = 'libcgroup'
+          $default_cgconfig_mount = '/cgroup'
+        }
+        default: {
+          fail('cgroups is only supported on EL 6 and 7.')
+        }
+      }
     }
     'Suse': {
       case $::lsbmajdistrelease {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,10 @@ class cgroups (
     fail('cgroups::package_name must be a string or an array.')
   }
 
+  validate_hash($mounts)
+  validate_hash($groups)
+
+
   case $::osfamily {
     'RedHat': {
       $default_package_name   = 'libcgroup'

--- a/metadata.json
+++ b/metadata.json
@@ -11,13 +11,15 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6"
+        "6",
+        "7"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,19 +20,16 @@ describe 'cgroups' do
       }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/etc/cgconfig.conf').with({
           'ensure'  => 'file',
           'path'    => '/etc/cgconfig.conf',
-          'notify'  => 'Service[cgconfig_service]',
+          'notify'  => 'Service[cgconfig]',
           'require' => 'Package[libcgroup]',
         })
-        should contain_file('cg_conf').with_content(
+        should contain_file('/etc/cgconfig.conf').with_content(
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 
-mount {
-  cpu = /cgroup;
-}
 
 })
       }
@@ -40,32 +37,15 @@ mount {
       it { should_not contain_file('cgroups_path_fix') }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('cgconfig').with({
           'ensure'  => 'running',
           'enable'  => 'true',
-          'name'    => 'cgconfig',
           'require' => 'Package[libcgroup]',
         })
       }
 
     end
 
-    ['5','7'].each do |release|
-      context "on EL #{release}" do
-        let(:facts) do
-          { :osfamily                  => 'RedHat',
-            :operatingsystemrelease    => "#{release}.0",
-            :operatingsystemmajrelease => release,
-          }
-        end
-
-        it 'should fail' do
-          expect {
-            should contain_class('cgroups')
-          }.to raise_error(Puppet::Error,/cgroups is only supported on EL 6./)
-        end
-      end
-    end
 
     context 'on Suse 11.2' do
       let(:facts) do
@@ -86,30 +66,20 @@ mount {
       }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/etc/cgconfig.conf').with({
           'ensure'  => 'file',
           'path'    => '/etc/cgconfig.conf',
-          'notify'  => 'Service[cgconfig_service]',
+          'notify'  => 'Service[cgconfig]',
           'require' => 'Package[libcgroup1]',
         })
-        should contain_file('cg_conf').with_content(
-%{# This file is being maintained by Puppet.
-# DO NOT EDIT
-
-mount {
-  cpu = /sys/fs/cgroup;
-}
-
-})
       }
 
       it { should_not contain_file('cgroups_path_fix') }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('cgconfig').with({
           'ensure'  => 'running',
           'enable'    => 'true',
-          'name'  => 'cgconfig',
           'require' => 'Package[libcgroup1]',
         })
       }
@@ -149,30 +119,20 @@ mount {
       }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/etc/cgconfig.conf').with({
           'ensure'  => 'file',
           'path'    => '/etc/cgconfig.conf',
-          'notify'  => 'Service[cgconfig_service]',
+          'notify'  => 'Service[cgconfig]',
           'require' => 'Package[libcgroup1]',
         })
-        should contain_file('cg_conf').with_content(
-%{# This file is being maintained by Puppet.
-# DO NOT EDIT
-
-mount {
-  cpu = /sys/fs/cgroup;
-}
-
-})
       }
 
       it { should_not contain_file('cgroups_path_fix') }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('cgconfig').with({
           'ensure'  => 'running',
           'enable'    => 'true',
-          'name'  => 'cgconfig',
           'require' => 'Package[libcgroup1]',
         })
       }
@@ -191,23 +151,17 @@ mount {
 
       it { should compile.with_all_deps }
 
-      it {
-        should contain_file('cg_conf').with_content(
-%{# This file is being maintained by Puppet.
-# DO NOT EDIT
-
-mount {
-  cpu = /cgroup;
-}
-
-kalle is king hallelulja})
-      }
 
       it { should_not contain_file('cgroups_path_fix') }
     end
 
     context 'On Suse 11.2' do
-      let(:params) { { :cgconfig_content => 'kalle is king hallelulja' } }
+      let(:params) { 
+        { 
+          :cgconfig_content => 'kalle is king hallelulja',
+          :mounts => { 'cpu' => '/sys/fs/cgroup' }
+        } 
+      }
       let(:facts) do
         { :osfamily               => 'Suse',
           :operatingsystemrelease => '11.2',
@@ -218,7 +172,7 @@ kalle is king hallelulja})
       it { should compile.with_all_deps }
 
       it {
-        should contain_file('cg_conf').with_content(
+        should contain_file('/etc/cgconfig.conf').with_content(
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 
@@ -245,13 +199,10 @@ kalle is king hallelulja})
       it { should compile.with_all_deps }
 
       it {
-        should contain_file('cg_conf').with_content(
+        should contain_file('/etc/cgconfig.conf').with_content(
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 
-mount {
-  cpu = /sys/fs/cgroup;
-}
 
 kalle is king hallelulja})
       }
@@ -291,7 +242,7 @@ kalle is king hallelulja})
         'ensure'  => 'directory',
         'path'    => '/kalle',
         'mode'    => '0775',
-        'require' => 'Service[cgconfig_service]',
+        'require' => 'Service[cgconfig]',
         })
       }
     end
@@ -309,10 +260,9 @@ kalle is king hallelulja})
       it { should compile.with_all_deps }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/usr/local/etc/cgconfig.conf').with({
           'ensure'  => 'file',
-          'path'    => '/usr/local/etc/cgconfig.conf',
-          'notify'  => 'Service[cgconfig_service]',
+          'notify'  => 'Service[cgconfig]',
           'require' => 'Package[libcgroup]',
         })
       }
@@ -346,10 +296,9 @@ kalle is king hallelulja})
       it { should compile.with_all_deps }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('mycgconfig').with({
           'ensure'  => 'running',
           'enable'  => 'true',
-          'name'    => 'mycgconfig',
           'require' => 'Package[libcgroup]',
         })
       }
@@ -389,13 +338,13 @@ kalle is king hallelulja})
       }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/etc/cgconfig.conf').with({
           'require' => 'Package[mylibcgroup]',
         })
       }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('cgconfig').with({
           'require' => 'Package[mylibcgroup]',
         })
       }
@@ -424,13 +373,13 @@ kalle is king hallelulja})
       }
 
       it {
-        should contain_file('cg_conf').with({
+        should contain_file('/etc/cgconfig.conf').with({
           'require' => [ 'Package[cgrouptools]', 'Package[libcgroup]' ],
         })
       }
 
       it {
-        should contain_service('cgconfig_service').with({
+        should contain_service('cgconfig').with({
           'require' => [ 'Package[cgrouptools]', 'Package[libcgroup]' ],
         })
       }
@@ -448,35 +397,6 @@ kalle is king hallelulja})
         expect {
           should contain_class('cgroups')
         }.to raise_error(Puppet::Error,/cgroups::package_name must be a string or an array./)
-      end
-    end
-  end
-
-  describe 'with cgconfig_mount parameter specified' do
-    context 'as a valid path' do
-      let(:params) { { :cgconfig_mount => '/tmp/cgroup' } }
-      let(:facts) do
-        { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      it { should compile.with_all_deps }
-
-    end
-
-    context 'as an invalid path' do
-      let(:params) { { :cgconfig_mount => 'invalid/path' } }
-      let(:facts) do
-        { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('cgroups')
-        }.to raise_error(Puppet::Error)
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,6 +46,22 @@ describe 'cgroups' do
 
     end
 
+    ['5','8'].each do |release|
+      context "on EL #{release}" do
+        let(:facts) do
+          { :osfamily                  => 'RedHat',
+            :operatingsystemrelease    => "#{release}.0",
+            :operatingsystemmajrelease => release,
+          }
+        end
+
+        it 'should fail' do
+          expect {
+            should contain_class('cgroups')
+          }.to raise_error(Puppet::Error,/cgroups is only supported on EL 6 and 7./)
+        end
+      end
+    end
 
     context 'on Suse 11.2' do
       let(:facts) do

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'cgroups::group' do
   
-  let (:title) { 'user_mgw-all' }
+  let (:title) { 'user/mgw-all' }
   let(:facts) do
     { :osfamily                  => 'RedHat',
       :operatingsystemrelease    => '7.1',
@@ -32,11 +32,11 @@ describe 'cgroups::group' do
     }}
 
     it do
-      should contain_file('/etc/cgconfig.d/user_mgw-all.conf').with({
+      should contain_file('/etc/cgconfig.d/user-mgw-all.conf').with({
         'notify' => 'Service[cgconfig]'
       })
-      should contain_file('/etc/cgconfig.d/user_mgw-all.conf').with_content(
-%{group user_mgw-all {
+      should contain_file('/etc/cgconfig.d/user-mgw-all.conf').with_content(
+%{group user/mgw-all {
   perm {
     task  {
       uid = root;

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -1,20 +1,8 @@
 require 'spec_helper'
 
-describe 'cgroups::group' do
-  let (:title) { 'test' }
-  context 'when declared before the cgroups class' do
-    it 'should fail' do
-      should raise_error(Puppet::Error,/Must include cgroups module before declaring cgroups::group resources/)
-    end
-  end
-end
 
 describe 'cgroups::group' do
   
-  let :pre_condition do
-    'class { "cgroups": }'
-  end
-
   let (:title) { 'user_mgw-all' }
   let(:facts) do
     { :osfamily                  => 'RedHat',

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe 'cgroups::group' do
+  let (:title) { 'test' }
+  context 'when declared before the cgroups class' do
+    it 'should fail' do
+      should raise_error(Puppet::Error,/Must include cgroups module before declaring cgroups::group resources/)
+    end
+  end
+end
+
+describe 'cgroups::group' do
+  
+  let :pre_condition do
+    'class { "cgroups": }'
+  end
+
+  let (:title) { 'user_mgw-all' }
+  let(:facts) do
+    { :osfamily                  => 'RedHat',
+      :operatingsystemrelease    => '7.1',
+      :operatingsystemmajrelease => '7',
+    }
+  end
+
+  context 'when declared' do
+    let (:params) { {
+      :permissions => {
+        'task' => {
+          'uid' => 'root',
+          'gid' => 'mgw-all'
+        },
+        'admin' => {
+          'uid' => 'root',
+          'gid' => 'mgw-all'
+        }
+      },
+      :controllers => {
+        'cpu' => {
+          'cpuset.mems' => '0',
+          'cpuset.cpus' => '0,1'
+        }
+      }
+    }}
+
+    it do
+      should contain_file('/etc/cgconfig.d/user_mgw-all.conf').with({
+        'notify' => 'Service[cgconfig]'
+      })
+      should contain_file('/etc/cgconfig.d/user_mgw-all.conf').with_content(
+%{group user_mgw-all {
+  perm {
+    task  {
+      uid = root;
+      gid = mgw-all;
+    }
+    admin  {
+      uid = root;
+      gid = mgw-all;
+    }
+  }
+
+  cpu {
+    cpuset.mems = 0;
+    cpuset.cpus = 0,1;
+  }
+
+}
+})
+    end
+  end
+end

--- a/templates/cgroup.conf.erb
+++ b/templates/cgroup.conf.erb
@@ -1,8 +1,12 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
+<% unless @mounts.empty? -%>
 mount {
-  cpu = <%= @cgconfig_mount_real %>;
+<%   @mounts.each do |p,v| -%>
+  <%= p %> = <%= v %>;
+<%   end -%>
 }
+<% end -%>
 
 <%= @cgconfig_content -%>

--- a/templates/group.conf.erb
+++ b/templates/group.conf.erb
@@ -1,0 +1,22 @@
+group <%= @name %> {
+<% unless @permissions.empty? -%>
+  perm {
+<%   @permissions.each do |type, params| -%>
+    <%= type %>  {
+<%     params.each do |p,v| -%>
+      <%= p %> = <%= v %>;
+<%     end -%>
+    }
+<%  end  -%>
+  }
+<% end -%>
+
+<% @controllers.each do |controller, params| -%>
+  <%= controller %> {
+<%   params.each do |p,v| -%>
+    <%= p %> = <%= v %>;
+<%   end -%>
+  }
+<% end -%>
+
+}


### PR DESCRIPTION
## Description 
I'm currently running off this fork as I made some major changes to make groups more configurable.  It would be nice to get this merged upstream and released (as a 2.0.0) - also I note this module is not on the forge, if accepted, could you release it please?

## Main changes

### RHEL 7 allowed
Whilst it's true that a lot of libcgroup configuration is obsolete on Redhat 7 there are still use cases for configuring stuff in cgconfig.conf/.d... namely groups therefore the fail condition for RedHat 7.0+ has been removed

### cgroups::group defined resource type
Previously this module just took a blob of static data in the `cgconfig_content` parameter and dumped it into cgconfig.conf.  While the cgconfig_content parameter still exists, the aim is that this should be used just for edge cases.  A `cgconfig::group` defined type has been added to allow more structured, cleaner, handling of group definitions and they are placed in the .d directory rather than in the main config file.

### mount{} configuration made optional
Previously the module would always require a cpu controller mounted in the mount {} section of cgconfig.conf.  As per above, there are very limited cases for doing this in cgconfig.conf now so this has been changed to default to not configuring this section.  An optional configuration parameter of `mounts` has been added to allow users to add mounts they require.

### Internal cleanup
A few things have been tweaked internally to make the module conform better to best practice, including removing the questionable 'USE_DEFAULTS' default setting in favour of undef, and changing resource titles to be the namevar rather than using a different name for the service and config file - there was no real reason to do this and it added confusion.

### Other
* Documentation and rspec updates to support the new/modified functionality.
* Removed ruby 1.8.7 from test coverage (the world has moved on)

## Detailed breakdown (from commit):

* Removed failure condition for Redhat 7.0+
* Added cgroups::group defined resource type
* BREAK: removed 'cfconfig_mount' parameter to cgroups class
* Added mounts parameter for optionally adding mount{} to config
* Added groups parameter for optionally adding cgroups::group types
* Changed 'USE_DEFAULTS' to better handling using undef
* Use actual resource titles as namevars rather than arb names
* Added 'config_d_path' parameter option
* DOC: removed example code showing groups in big data blob
* DOC: added documentation for the cgroups::group type
* DOC: added documentation for the mounts parameter
* RSPEC: modified tests for file contents (mount)
* RSPEC: modified tests to look for correct service titles
* RSPEC: added rspec tests for the cgroups::group define