### PR TITLE
package_name_default should be an array for EL7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,14 @@ class cgroups (
   case $::osfamily {
     'RedHat': {
       case $::operatingsystemmajrelease {
-        '6','7': {
+        '6': {
           $package_name_default = 'libcgroup'
+        }
+        '7': {
+          $package_name_default = [
+            'libcgroup',
+            'libcgroup-tools',
+          ]
         }
         default: {
           fail('cgroups is only supported on EL 6 and 7.')


### PR DESCRIPTION
Service[cgconfig] fails with default options at the moment as cgconfig is now part of
libcgroup-tools.