### PR TITLE
Add support for paths that use template variables.

### DIFF
--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -28,6 +28,28 @@ describe 'cgroups::group' do
     end
   end
 
+  context 'with template' do
+    let(:title) { 'rspec/%u' }
+
+    content = <<-END.gsub(/^\s+\|/, '')
+      |# This file is being maintained by Puppet.
+      |# DO NOT EDIT
+      |
+      |template rspec/%u {
+      |
+      |}
+    END
+
+    it do
+      should contain_file('/etc/cgconfig.d/rspec-%u.conf').with({
+        'ensure'  => 'file',
+        'notify'  => 'Service[cgconfig]',
+        'content' => content,
+      })
+    end
+  end
+
+
   context 'with all parameters set to valid values' do
     let(:params) do
       {

--- a/templates/group.conf.erb
+++ b/templates/group.conf.erb
@@ -1,7 +1,11 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
+<% unless @name.include? "%" -%>
 group <%= @name %> {
+<% else -%>
+template <%= @name %> {
+<% end -%>
 <% unless @permissions.empty? -%>
 
   perm {


### PR DESCRIPTION
Cgconfig supports the use of template parameters, this patch will convert groups that use these parameters to templates.