### PR TITLE
Fix TravisCI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ coverage/
 spec/fixtures/modules/*
 spec/fixtures/manifests/*
 Gemfile.lock
+vendor/*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,17 @@ language: ruby
 cache: bundler
 
 before_install:
-  - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'bundle exec rake validate lint spec'
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 1.9.3
@@ -38,8 +31,22 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5"
+    before_install:
+      - bundle -v
+      - rm Gemfile.lock || true
+      - gem update --system --no-doc
+      - gem update bundler --no-doc
+      - gem --version
+      - bundle -v
   - rvm: 2.5.1
     env: PUPPET_GEM_VERSION="~> 6"
+    before_install:
+      - bundle -v
+      - rm Gemfile.lock || true
+      - gem update --system --no-doc
+      - gem update bundler --no-doc
+      - gem --version
+      - bundle -v
 
 notifications:
   email: false


### PR DESCRIPTION
* Remove gem updates for Ruby < 2.3 as `rubygems-update` now requires >= 2.3.0
* Remove tests for Ruby 1.8.7 as 1.8.7 is completely deprecated now
* Move rspec config options from `.travis.yml` to `.rspec`
* Add the ./vendor directory to `.gitignore`